### PR TITLE
[READY] - Init minimal bootable iso for ham utils

### DIFF
--- a/iso.nix
+++ b/iso.nix
@@ -1,0 +1,25 @@
+{ modulesPath, lib, ... }:
+let
+  ham-overlay = import ./default.nix;
+  nixpkgs = import <nixpkgs> { overlays = [ ham-overlay ]; };
+in
+with nixpkgs;
+{
+  imports = [
+    "${modulesPath}/installer/cd-dvd/installation-cd-minimal.nix"
+  ];
+
+  # Installs all necessary packages for the iso
+  environment.systemPackages = [
+    aprx
+    tncattach
+    libax25
+    pat
+    flashtnc
+  ];
+  # use the latest Linux kernel
+  boot.kernelPackages = pkgs.linuxPackages_latest;
+
+  # Needed for https://github.com/NixOS/nixpkgs/issues/58959
+  boot.supportedFilesystems = lib.mkForce [ "btrfs" "reiserfs" "vfat" "f2fs" "xfs" "ntfs" "cifs" ];
+}


### PR DESCRIPTION
## Description

Adding a minimal, bootable iso that includes all utilities in this overlay

## Tests
- Able to boot into live environment and binaries are present in the environment