### PR TITLE
[READY] - Ham kernel mods, pat static and axports

### DIFF
--- a/iso.nix
+++ b/iso.nix
@@ -9,14 +9,31 @@ with nixpkgs;
     "${modulesPath}/installer/cd-dvd/installation-cd-minimal.nix"
   ];
 
-  # Installs all necessary packages for the iso
-  environment.systemPackages = [
-    aprx
-    tncattach
-    libax25
-    pat
-    flashtnc
-  ];
+  environment = {
+    # Installs all necessary packages for the iso
+    systemPackages = [
+      aprx
+      tncattach
+      libax25
+      pat
+      flashtnc
+    ];
+
+    # libax25, etc. are set to assume the common config path
+    # TODO: Definitely need to come up with a beter way to deal with this
+    etc."ax25/axports" = {
+      text = ''
+      # me callsign speed paclen window description
+      #
+      wl2k km6lbu-6 57600 255 7 Winlink
+      '';
+
+      # The UNIX file mode bits
+      mode = "0644";
+    };
+
+  };
+
   # use the latest Linux kernel
   boot.kernelPackages = pkgs.linuxPackages_latest;
 

--- a/iso.nix
+++ b/iso.nix
@@ -8,6 +8,24 @@ with nixpkgs;
   imports = [
     "${modulesPath}/installer/cd-dvd/installation-cd-minimal.nix"
   ];
+  boot.kernelPatches = [ {
+        name = "packet-radio-protocols";
+        patch = null;
+        extraConfig = ''
+              HAMRADIO y
+              AX25 y
+              AX25_DAMA_SLAVE y
+              NETROM m
+              ROSE m
+              MKISS y
+              6PACK y
+              BPQETHER y
+              BAYCOM_SER_FDX y
+              BAYCOM_SER_HDX y
+              BAYCOM_PAR m
+              YAM y
+        '';
+  } ];
 
   environment = {
     # Installs all necessary packages for the iso
@@ -35,7 +53,7 @@ with nixpkgs;
   };
 
   # use the latest Linux kernel
-  boot.kernelPackages = pkgs.linuxPackages_latest;
+  #boot.kernelPackages = pkgs.linuxPackages_latest;
 
   # Needed for https://github.com/NixOS/nixpkgs/issues/58959
   boot.supportedFilesystems = lib.mkForce [ "btrfs" "reiserfs" "vfat" "f2fs" "xfs" "ntfs" "cifs" ];

--- a/iso.nix
+++ b/iso.nix
@@ -31,6 +31,7 @@ with nixpkgs;
     # Installs all necessary packages for the iso
     systemPackages = [
       aprx
+      ax25-tools
       tncattach
       libax25
       pat

--- a/pkgs/ax25-tools/default.nix
+++ b/pkgs/ax25-tools/default.nix
@@ -12,6 +12,10 @@ stdenv.mkDerivation rec {
     sha256 = "1kv9b0vzapl69067q0qq8cm840f1cnxf6qdiksm78q5jjpnis5rs";
   };
 
+  # Ignore prefixing to /nix/store
+  # TODO: Make prefix configurable
+  configureFlags = [ "--sysconfdir=/etc" ];
+
   meta = with lib; {
     description = "ax25 tools";
     homepage = "https://www.linux-ax25.org/wiki/ax25-tools";

--- a/pkgs/libax25/default.nix
+++ b/pkgs/libax25/default.nix
@@ -12,8 +12,13 @@ stdenv.mkDerivation rec {
     sha256 = "1xnxab6n8w8b00dmg5idb6xwqs3llqsl0wv6s3xkf72pn1p1f7k5";
   };
 
+  # Ignore prefixing to /nix/store
+  # TODO: Make prefix configurable
+  configureFlags = [ "--sysconfdir=/etc" ];
+
   # Build libax25 staticly since downstream pat wants it to be static
   LDFLAGS="-static-libgcc -static";
+
   meta = with lib; {
     description = "A set of functions making it easier to write hamradio programs";
     homepage = "https://www.linux-ax25.org/wiki/Libax25";

--- a/pkgs/libax25/default.nix
+++ b/pkgs/libax25/default.nix
@@ -1,8 +1,10 @@
-{ lib, stdenv }:
+{ lib, stdenv, glibc }:
 
 stdenv.mkDerivation rec {
   pname = "libax25";
   version = "0.0.12-rc5";
+
+  buildInputs = [ glibc glibc.static ];
 
   # Sources for ax25 can be found here: https://www.linux-ax25.org/pub/
   src = fetchTarball {
@@ -10,6 +12,8 @@ stdenv.mkDerivation rec {
     sha256 = "1xnxab6n8w8b00dmg5idb6xwqs3llqsl0wv6s3xkf72pn1p1f7k5";
   };
 
+  # Build libax25 staticly since downstream pat wants it to be static
+  LDFLAGS="-static-libgcc -static";
   meta = with lib; {
     description = "A set of functions making it easier to write hamradio programs";
     homepage = "https://www.linux-ax25.org/wiki/Libax25";

--- a/pkgs/pat/default.nix
+++ b/pkgs/pat/default.nix
@@ -13,14 +13,18 @@ buildGoModule rec {
   };
 
   vendorSha256 = "00dfhb34aabqhy4zyvz5389a502p7jnmwb3zglsdvvmy6hr9rk59";
-  
+
+  # Seems to work out instead of explicitly setting CGO_LDFLAGS & CGO_CFLAGS
   buildInputs = [ libax25 ];
-  
+
+  # tags need to be specified for libax25 regardless of it being in build PATH
+  # https://github.com/la5nta/pat/blob/18d49336be03f6873ba377a6ad127a782205b09c/make.bash#L58
+  tags = [ "libax25" ];
+
   # Mimicked dependencies and build procedure
   # https://github.com/la5nta/pat/blob/master/make.bash
   # Need to fix rev to actually be commit hash
-  buildFlagsArray = [
-    "-ldflags="
+  ldflags = [
     "-X main.GitRev=${rev}"
   ];
 


### PR DESCRIPTION
# Description

- Iso was missing kernel mods for ham radio functionality
- pat tool was missing libax25 support due to `tags` missing
- Support common `/etc/ax25/axports`

## Tests
- Was able to send and receive winlink on 2m with pat tool