### PR TITLE
[READY] - Init ax25-apps @ 0.0.8-rc5

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,0 +1,2 @@
+iso:
+	nix-build '<nixpkgs/nixos>' -A config.system.build.isoImage -I nixos-config=iso.nix

--- a/default.nix
+++ b/default.nix
@@ -4,6 +4,7 @@ self: super:
   tncattach = super.callPackage ./pkgs/tncattach { };
   libax25 = super.callPackage ./pkgs/libax25 { };
   ax25-tools = super.callPackage ./pkgs/ax25-tools { };
+  ax25-apps = super.callPackage ./pkgs/ax25-apps { };
   pat = super.callPackage ./pkgs/pat { };
   flashtnc = super.callPackage ./pkgs/flashtnc { };
   maidenhead = super.callPackage ./pkgs/maidenhead { };

--- a/iso.nix
+++ b/iso.nix
@@ -37,6 +37,7 @@ with nixpkgs;
       libax25
       pat
       flashtnc
+      tmux
     ];
 
     # libax25, etc. are set to assume the common config path

--- a/iso.nix
+++ b/iso.nix
@@ -32,6 +32,7 @@ with nixpkgs;
     systemPackages = [
       aprx
       ax25-tools
+      ax25-apps
       tncattach
       libax25
       pat

--- a/pkgs/ax25-apps/default.nix
+++ b/pkgs/ax25-apps/default.nix
@@ -1,0 +1,26 @@
+{ lib, stdenv, libax25, ncurses }:
+
+stdenv.mkDerivation rec {
+  pname = "ax25-apps";
+  version = "0.0.8-rc5";
+
+  buildInputs = [ libax25 ncurses ];
+
+  # Sources for ax25 can be found here: https://www.linux-ax25.org/pub/
+  src = fetchTarball {
+    url = "http://www.linux-ax25.org/pub/ax25-apps/ax25-apps-0.0.8-rc5.tar.gz";
+    sha256 = "sha256:14gm3zg5nj2jkgm0cjkqkznasq4svg0wxms6gk059lrjbmg4m46h";
+  };
+
+  # Ignore prefixing to /nix/store
+  # TODO: Make prefix configurable
+  configureFlags = [ "--sysconfdir=/etc" ];
+
+  meta = with lib; {
+    description = "programs for the hamradio protocol AX.25 that would be used by normal users";
+    homepage = "https://www.linux-ax25.org/wiki/ax25-apps";
+    license = licenses.lgpl21Only;
+    maintainers =  with maintainers; [ sarcasticadmin ];
+    platforms = platforms.unix;
+  };
+}


### PR DESCRIPTION
## Description

Fixes: #9 

Init ax25-apps (specifically for `listen`) command to be able to monitor ax25 traffic on devices

## AC
- iso build
- `listen` tested to ensure functionality during winlink transmissions via `pat`