### PR TITLE
[READY] - Init hamlib unstable

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -8,4 +8,5 @@ self: super:
   pat = super.callPackage ./pkgs/pat { };
   flashtnc = super.callPackage ./pkgs/flashtnc { };
   maidenhead = super.callPackage ./pkgs/maidenhead { };
+  hamlib = super.callPackage ./pkgs/hamlib { };
 }

--- a/pkgs/hamlib/default.nix
+++ b/pkgs/hamlib/default.nix
@@ -1,0 +1,22 @@
+{ lib, stdenv, fetchgit, autoreconfHook }:
+
+stdenv.mkDerivation rec {
+  pname = "hamlib-unstable";
+  version = "2022-04-28";
+
+  src = fetchgit {
+    url = "https://github.com/Hamlib/Hamlib";
+    rev = "4b64d5f7c37882c6bddcaad82be8c7b3dd0aace4";
+    sha256 = "sha256-z8h9pYiNSAj6wmGyGABI88+NTCzDA4u/a0PimlP90rY=";
+  };
+
+  nativeBuildInputs = [ autoreconfHook ];
+
+  meta = with lib; {
+    description = "Ham radio control library for rigs, rotators, tuners, and amplifiers";
+    homepage = "https://github.com/Hamlib/Hamlib";
+    license = licenses.lgpl21Only;
+    maintainers = with maintainers; [ sarcasticadmin ];
+    platforms = platforms.linux;
+  };
+}

--- a/shell.nix
+++ b/shell.nix
@@ -11,5 +11,6 @@ mkShell {
     ax25-tools
     pat
     flashtnc
+    hamlib
   ];
 }


### PR DESCRIPTION
## Description

Add `hamlib` unstable to nixpkg overlay

## Tests
- `hamlib` binaries workable via iso
  - `rigctl` and `ampctl` help menus work as expected (need to get a cable to control my FT-857d)
  - manpages present as well