### PR TITLE
[READY] - update flashtnc to firmware 3/4.14

### DIFF
--- a/pkgs/flashtnc/add-shebang.patch
+++ b/pkgs/flashtnc/add-shebang.patch
@@ -4,6 +4,6 @@ index 65ffb19..d571a33 100644
 +++ b/flashtnc.py
 @@ -1,3 +1,4 @@
 +#!/usr/bin/env python3
- # N9600A Firmware Updater version d
+ # N9600A Firmware Updater version f
  # Nino Carrillo
  # David Arthur

--- a/pkgs/flashtnc/default.nix
+++ b/pkgs/flashtnc/default.nix
@@ -5,13 +5,13 @@
 }:
 stdenv.mkDerivation rec {
   pname = "flashtnc-unstable";
-  version = "2021-07-23";
+  version = "2022-05-04";
 
   src = fetchFromGitHub {
     owner = "ninocarrillo";
-    rev = "f6b4be42754f45f340234b071ac8a779e41a7998";
+    rev = "a7c8d820e803c20ca28e9ebf3042c97d1a2ba88e";
     repo = "flashtnc";
-    sha256 = "1pnhh4hbpcb7iyliqsaz6l00jgsapsddffnbb2697bn6ygk9cnvh";
+    sha256 = "sha256-fYfQbfE9bEcIDuvc00ecxMtR1yuHhNRhFLVZqKMOhQg=";
   };
 
   buildInputs = [


### PR DESCRIPTION
## Description

New release of flashtnc was released: 3/4.14 for flashing ninotncs

## AC
- Updated the flashtnc drv
- Tested flashing firmware on ninotnc A4 (success)