### PR TITLE
init ardopc @ unstable-2023-01-13

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -20,6 +20,7 @@
         with final.pkgs;
         rec {
           aprx = callPackage ./pkgs/aprx { };
+          ardopc = callPackage ./pkgs/ardopc { };
           pat = callPackage ./pkgs/pat { };
           flashtnc = callPackage ./pkgs/flashtnc { };
           maidenhead = callPackage ./pkgs/maidenhead { };
@@ -31,6 +32,7 @@
         with pkgs; {
           inherit
             aprx
+            ardopc
             pat
             flashtnc
             maidenhead

--- a/pkgs/ardopc/default.nix
+++ b/pkgs/ardopc/default.nix
@@ -1,0 +1,35 @@
+{ lib
+, stdenv
+, fetchzip
+, alsa-lib
+}:
+let
+  src = fetchzip {
+    url = "https://www.cantab.net/users/john.wiseman/Downloads/Beta/ARDOPProjects.zip";
+    sha256 = "sha256-YHVsTO0f1VlJSG32RvkPDQx9jVouLFDl5/r+WR/xlLE=";
+  };
+in
+stdenv.mkDerivation rec {
+  inherit src;
+
+  pname = "ardopc";
+
+  version = "unstable-2023-01-13";
+
+  sourceRoot = "${src.name}/ARDOPC";
+
+  buildInputs = [ alsa-lib ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    install -D -m 755 ardopc $out/bin/ardopc
+  '';
+
+  meta = with lib; {
+    description = "Amateur Radio Digital Open Protocol";
+    homepage = "http://www.cantab.net/users/john.wiseman/Downloads/Beta/";
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ sarcasticadmin ];
+    platforms = platforms.linux;
+  };
+}


### PR DESCRIPTION
## Description

init [ardopc](https://www.cantab.net/users/john.wiseman/Documents/ARDOPC.html) for HF winlink

## Tests

Running the binary works on `NixOS 22.11`
```
$ ./result/bin/ardopc                                                          
ardopc Version 1.0.4.1qBPQ   
ARDOPC listening on port 8515                    
Capture Devices                                                                                   
                                                 
Card 0, ID `Generic', name `HD-Audio Generic'                                                     
                                                                                                  
Card 1, ID `Generic_1', name `HD-Audio Generic'                                                   
  Device hw:1,0 ID `ALC257 Analog', name `ALC257 Analog', 1 subdevices (1 available)
    2 channels,  sampling rate 44100..192000 Hz
                                                 
Card 2, ID `acp', name `acp'            
  Device hw:2,0 ID `DMIC capture dmic-hifi-0', name `', 1 subdevices (1 available)
    2 channels,  sampling rate 48000..48000 Hz                                                    
                                                                                                  
Card 3, ID `C920', name `HD Pro Webcam C920'                                                      
  Device hw:3,0 ID `USB Audio', name `USB Audio', 1 subdevices (1 available)
    2 channels,  sampling rate 16000..32000 Hz    
Card 4, ID `Au', name `ThinkPad USB-C Dock Gen2 USB Au'
  Device hw:4,0 ID `USB Audio', name `USB Audio', 1 subdevices (1 available)
    1 channel,  sampling rate 8000..48000 Hz

Playback Devices

Card 0, ID `Generic', name `HD-Audio Generic'
  Device hw:0,3 ID `HDMI 0', name `LG ULTRAWIDE', 1 subdevices (1 available)
    2 channels,  sampling rate 32000..48000 Hz
  Device hw:0,7 ID `HDMI 1', name `HDMI 1', 1 subdevices (1 available)
    2..8 channels, sampling rate 32000..192000 Hz 
  Device hw:0,8 ID `HDMI 2', name `HDMI 2', 1 subdevices (1 available)
    2..8 channels, sampling rate 32000..192000 Hz 

Card 1, ID `Generic_1', name `HD-Audio Generic'
  Device hw:1,0 ID `ALC257 Analog', name `ALC257 Analog', 1 subdevices (1 available)
    2 channels,  sampling rate 44100..48000 Hz

Card 2, ID `acp', name `acp'

Card 3, ID `C920', name `HD Pro Webcam C920'

Card 4, ID `Au', name `ThinkPad USB-C Dock Gen2 USB Au'
  Device hw:4,0 ID `USB Audio', name `USB Audio', 1 subdevices (1 available)
    2 channels,  sampling rate 8000..48000 Hz

Using Both Channels of soundcard for RX
Using Both Channels of soundcard for TX
Opening Playback Device ARDOP Rate 12000
ALSA lib pcm.c:2737:(snd_pcm_open_noupdate) Unknown PCM ARDOP
cannot open playback audio device ARDOP (No such file or directory)
ardopc listening on port 8515
```