### PR TITLE
[READY] - init wwl @ 1.3

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -25,6 +25,7 @@
           flashtnc = callPackage ./pkgs/flashtnc { };
           maidenhead = callPackage ./pkgs/maidenhead { };
           rmsgw = callPackage ./pkgs/rmsgw { };
+          wwl = callPackage ./pkgs/wwl { };
         }
       );
 
@@ -36,7 +37,8 @@
             pat
             flashtnc
             maidenhead
-            rmsgw;
+            rmsgw
+            wwl;
         };
     };
 

--- a/pkgs/wwl/default.nix
+++ b/pkgs/wwl/default.nix
@@ -1,0 +1,27 @@
+{ lib
+, stdenv
+, fetchzip
+}:
+stdenv.mkDerivation rec {
+  pname = "wwl";
+
+  version = "1.3";
+
+  src = fetchzip {
+    url = "http://www.db.net/downloads/wwl+db-1.3.tgz";
+    sha256 = "sha256-kOW4znD6IobcHAaaIiebfqI662OQZoc07La52ckxo1s=";
+  };
+
+  makeFlags = [ "PREFIX=$(out)" "MANPREFIX=$(out)/man" ];
+
+  preInstall = ''
+    mkdir -p $out/bin $out/man/man1
+  '';
+
+  meta = with lib; {
+    description = "Maidenhead locator utility";
+    homepage = "http://www.db.net/downloads/";
+    maintainers = with maintainers; [ sarcasticadmin ];
+    platforms = platforms.linux;
+  };
+}


### PR DESCRIPTION
## Description

Adding maidenhead calculator to be able to calculate distances between grid squares. Will be
useful when leveraging the winlink RMS gateway lists to find closest gateways.

## Test

`wwl`:

```
$ ./result/bin/wwl DM12lt DM12ot
qrb: 23 kilometers, azimuth: 90 degrees
```

`locator`:

```
$ ./result/bin/locator DM12ot
Locator    : DM12OT
Coordinates: Long: (W) -116.83 Lat : (N) 32.7917
```
