### PR TITLE
[READY] - upgrade to nixos-23.05 and bump flashtnc unstable

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,16 +2,16 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1682268651,
-        "narHash": "sha256-2eZriMhnD24Pmb8ideZWZDiXaAVe6LzJrHQiNPck+Lk=",
+        "lastModified": 1685865905,
+        "narHash": "sha256-XJZ/o17eOd2sEsGif+/MQBnfa2DKmndWgJyc7CWajFc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e78d25df6f1036b3fa76750ed4603dd9d5fe90fc",
+        "rev": "e7603eba51f2c7820c0a182c6bbb351181caa8e7",
         "type": "github"
       },
       "original": {
         "id": "nixpkgs",
-        "ref": "nixos-unstable",
+        "ref": "nixos-23.05",
         "type": "indirect"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,7 @@
 {
   inputs = {
     # many pkgs upstream havent made it in an official release yet
-    nixpkgs.url = "nixpkgs/nixos-unstable";
+    nixpkgs.url = "nixpkgs/nixos-23.05";
   };
   outputs = { self, nixpkgs, ... }:
     let

--- a/pkgs/flashtnc/default.nix
+++ b/pkgs/flashtnc/default.nix
@@ -5,13 +5,13 @@
 }:
 stdenv.mkDerivation rec {
   pname = "flashtnc-unstable";
-  version = "2023-03-15";
+  version = "2023-05-08";
 
   src = fetchFromGitHub {
     owner = "ninocarrillo";
-    rev = "6f17ae1887d770569523909ef39dfb975f2fd71b";
+    rev = "a41861199d6f887eb58d8cbe492eeeeac74aabb4";
     repo = "flashtnc";
-    sha256 = "sha256-9/nwgAcvZ9aLyHHSyEyIoS3fmOlsmHQdTR2edrozWhI=";
+    sha256 = "sha256-s/ljNc4Nsf54DfGIs1jIqdLbjmFekQZ8EJrbZJ5Bg4s=";
   };
 
   buildInputs = [


### PR DESCRIPTION
## Description

- flashtnc: 2023-03-15 -> 2023-05-08
- upgrade flake and lock to nixos-23.05
