### PR TITLE
[READY] - forking instead of oneshot for ax25d

### DIFF
--- a/modules/ax25d.nix
+++ b/modules/ax25d.nix
@@ -39,7 +39,7 @@ in
       before = [ "ax25.target" ];
       wantedBy = [ "ax25.target" ];
       bindsTo = [ "ax25.target" ];
-      serviceConfig.Type = "oneshot";
+      serviceConfig.Type = "forking";
       serviceConfig.ExecStart = "${kissScript}";
     };
   };


### PR DESCRIPTION
## Description

`ax25d` was starting but killing child process due to `type=oneshot` on the service.

`type=forking` sets the appropriate behavior for ax25d service

## Tests

- Confirmed on local setup with ninotnc
