### PR TITLE
[READY] - aprx: fix txOk option

### DIFF
--- a/modules/aprx.nix
+++ b/modules/aprx.nix
@@ -12,7 +12,7 @@ let
       mycall ${cfg.callSign}
       <interface>
         ax25-device $mycall
-        tx-ok ${toString cfg.txOk}
+        tx-ok ${boolToString cfg.txOk}
       </interface>
       <digipeater>
         transmitter $mycall

--- a/modules/aprx.nix
+++ b/modules/aprx.nix
@@ -54,6 +54,12 @@ in
       description = lib.mdDoc "Baud rate to the TNC";
     };
 
+    txOk = mkOption {
+      type = types.bool;
+      default = true;
+      description = lib.mdDoc "enable TX for digipeater";
+    };
+
     configFile = mkOption {
       type = types.nullOr types.path;
       default = null;


### PR DESCRIPTION
## Description

missing txOk option for the aprx module

## Tests

- validated on `mulligan`
